### PR TITLE
fix: change BunRedis client for ioredis

### DIFF
--- a/src/configs/databases/sources/RedisConfig.ts
+++ b/src/configs/databases/sources/RedisConfig.ts
@@ -1,9 +1,19 @@
-import { RedisClient } from "bun";
+import {
+  REDIS_PASSWORD,
+  REDIS_PORT,
+  REDIS_URL,
+  REDIS_USERNAME,
+} from "@configs/env/Env";
+import Redis from "ioredis";
 
-if (!Bun.env.REDIS_URL)
-  throw new Error("REDIS_URL is not defined in environment variables");
+const redisClient = new Redis({
+  host: REDIS_URL,
+  password: REDIS_PASSWORD,
+  username: REDIS_USERNAME,
+  port: REDIS_PORT,
+});
 
-const redisClient = new RedisClient(Bun.env.REDIS_URL, {
-  autoReconnect: true,
+redisClient.on("error", (err) => {
+  console.error("[ioredis] Error event:", err);
 });
 export default redisClient;


### PR DESCRIPTION
The redis client was changed to IOREDIS, in order to meet the requisitors of the issue, also I stopped using Bun.env because accessing environment variables all the time is expensive, therefore I simply import them once and with that I do not access all the time to the environment variables, in the following PR I explain the process of env’s