### PR TITLE
Add MIT License and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing Guidelines
+
+Thank you for considering contributing to this project!  
+To maintain consistency and quality, please follow these guidelines.
+
+---
+
+## 📐 Architecture & Principles
+
+- Follow **Clean Architecture**:
+  - Separate **Core**, **Application**, **Infrastructure**, and **Interfaces** layers.
+  - Business logic must not depend on frameworks or external services.
+  - Boundaries must remain explicit and well-defined.
+
+- Apply fundamental design principles:
+  - **KISS** (Keep It Simple, Stupid) → Avoid unnecessary complexity.
+  - **SOLID** → Ensure maintainable, extensible, and testable code.
+  - **DRY** (Don't Repeat Yourself) → Reuse abstractions, avoid duplication.
+  - **High Cohesion & Low Coupling** → Each module should do one thing well and depend minimally on others.
+  - **Use interfaces** to define contracts and decouple implementations.
+
+- Encourage the use of **Design Patterns** when applicable:  
+  Reference: [Refactoring Guru - Design Patterns](https://refactoring.guru/design-patterns)
+
+---
+
+## 🌳 Branching Strategy
+
+We follow a **two-main-branch workflow**:
+
+- `main` → Always stable, reflects production-ready code.
+- `develop` → Integration branch, where all features, fixes, and chores are merged before reaching `main`.
+
+### 🔧 Rules
+
+- Always branch **from `develop`** when starting new work.
+- Use prefixes to classify branches:
+  - `feat/*` → New features  
+  - `fix/*` → Bug fixes  
+  - `chore/*` → Maintenance tasks (dependencies, configs, etc.)  
+  - `refactor/*` → Code improvements without new features  
+  - `docs/*` → Documentation updates  
+
+### 🌐 Example Workflow
+
+1. Create a new branch from `develop`:  
+
+   ```sh
+   git checkout develop
+   git pull
+   git checkout -b feat/authentication

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 Samuel Luciano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Introduce an MIT License file to clarify usage rights and add contributing guidelines to enhance collaboration within the project.