### PR TITLE
Update Redis configuration and enhance error logging

### DIFF
--- a/src/configs/databases/sources/RedisConfig.ts
+++ b/src/configs/databases/sources/RedisConfig.ts
@@ -1,13 +1,13 @@
 import {
   REDIS_PASSWORD,
   REDIS_PORT,
-  REDIS_URL,
+  REDIS_HOST,
   REDIS_USERNAME,
 } from "@configs/env/Env";
 import Redis from "ioredis";
 
 const redisClient = new Redis({
-  host: REDIS_URL,
+  host: REDIS_HOST,
   password: REDIS_PASSWORD,
   username: REDIS_USERNAME,
   port: REDIS_PORT,

--- a/src/configs/env/Env.ts
+++ b/src/configs/env/Env.ts
@@ -1,12 +1,12 @@
 import z from "zod";
 
 const enviromentsVariables = z.object({
-  REDIS_URL: z.string().min(1).default("http://localhost:6379"),
-  REDIS_PASSWORD: z.string().min(8),
+  REDIS_HOST: z.string().min(1).default("localhost"),
+  REDIS_PASSWORD: z.string(),
   REDIS_USERNAME: z.string().min(1),
   REDIS_PORT: z.coerce.number().default(6379),
   JWT_SECRET: z.string().min(1).default("secret"),
-  LOG_LEVEL: z.string().min(4).default("dev"),
+  LOG_LEVEL: z.string().default("debug"),
   TURSO_AUTH_TOKEN: z.string().min(8).default("your-token"),
   TURSO_DATABASE_URL: z.string().min(1).default("https://tursodb.com"),
 });
@@ -23,7 +23,7 @@ export const {
   LOG_LEVEL,
   REDIS_PASSWORD,
   REDIS_PORT,
-  REDIS_URL,
+  REDIS_HOST,
   REDIS_USERNAME,
   TURSO_AUTH_TOKEN,
   TURSO_DATABASE_URL,

--- a/src/modules/Auth/application/useCases/LoginUseCase.ts
+++ b/src/modules/Auth/application/useCases/LoginUseCase.ts
@@ -59,8 +59,14 @@ export class LoginUseCase {
       const accessToken = await createJWT({ userId: user.userId, sessionId });
 
       return Result.ok({ accessToken, refreshToken });
-    } catch (error) {
-      log.error({ error }, "Login failed");
+    } catch (err) {
+      log.error(
+        {
+          message: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        },
+        "Login failed"
+      );
       return Result.fail("Login failed");
     }
   }

--- a/src/modules/Auth/application/useCases/RegenerateTokensUseCase.ts
+++ b/src/modules/Auth/application/useCases/RegenerateTokensUseCase.ts
@@ -14,7 +14,7 @@ import { log } from "app";
 export class RegenerateTokensUseCase {
   constructor(
     @inject(AUTH_INFRASTRUCTURE_TOKENS.ISessionService)
-    private sessionService: ISessionService,
+    private sessionService: ISessionService
   ) {}
 
   async execute(input: unknown) {
@@ -24,9 +24,7 @@ export class RegenerateTokensUseCase {
 
       if (!success) {
         const { message } = handleZodError(error);
-        log.warn(
-          `RegenerateTokensUseCase - Validation failed: ${message}`
-        );
+        log.warn(`RegenerateTokensUseCase - Validation failed: ${message}`);
         return Result.fail(message);
       }
 
@@ -43,9 +41,7 @@ export class RegenerateTokensUseCase {
       // Validate session exists and is valid
       const isValid = await this.sessionService.validate(userId, sessionId);
       if (!isValid) {
-        log.warn(
-          `RegenerateTokensUseCase - Invalid session: ${sessionId}`
-        );
+        log.warn(`RegenerateTokensUseCase - Invalid session: ${sessionId}`);
         return Result.fail("Invalid session");
       }
 
@@ -64,7 +60,6 @@ export class RegenerateTokensUseCase {
         sessionId: newSession,
       });
 
-      
       log.info(
         `RegenerateTokensUseCase - Tokens regenerated for user: ${userId}, session: ${sessionId}`
       );
@@ -74,7 +69,13 @@ export class RegenerateTokensUseCase {
         refreshToken: newRefreshToken,
       });
     } catch (error) {
-      log.error(`RegenerateTokensUseCase - Error: ${error}`);
+      log.error(
+        {
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+        "RegenerateTokensUseCase - Failed to regenerate tokens"
+      );
       return Result.fail("Failed to regenerate tokens");
     }
   }

--- a/src/modules/Auth/infrastructure/repositories/sessions/RedisSessionRepository.ts
+++ b/src/modules/Auth/infrastructure/repositories/sessions/RedisSessionRepository.ts
@@ -1,13 +1,13 @@
 import { ISessionEntity } from "@modules/Auth/core/models/ISessionEntity";
 import { SessionMapper } from "../../mappers/SessionMapper";
 import { ISessionRepository } from "@modules/Auth/core/repositories/ISessionRepository";
-import { RedisClient } from "bun";
 
 import { inject, injectable } from "tsyringe";
+import Redis from "ioredis";
 
 @injectable()
 export class RedisSessionRepository implements ISessionRepository {
-  constructor(@inject(RedisClient) private redisClient: RedisClient) {}
+  constructor(@inject(Redis) private redisClient: Redis) {}
   async findByRefreshToken(
     refreshToken: string
   ): Promise<ISessionEntity | null> {

--- a/src/shared/di/Container.ts
+++ b/src/shared/di/Container.ts
@@ -1,17 +1,15 @@
 import redisClient from "@configs/databases/sources/RedisConfig";
 import { turso } from "@configs/databases/sources/TursoConfig";
-import { Client } from "@libsql/client";
 import { AuthInfrastructureModule } from "@modules/Auth/infrastructure/InfrastructureContainer";
 import { ProfileInfrastructureModule } from "@modules/Profile/infrastructure/InfrastructureContainer";
-import { RedisClient } from "bun";
 import prisma from "configs/databases/sources/PrismaConfig";
-import { LoggerConfig } from "configs/logger";
 import { PrismaClient } from "generated/prisma";
 import { container } from "tsyringe";
 import { SHARED_TOKENS } from "./SharedTokens";
+import Redis from "ioredis";
 
 container.registerInstance<PrismaClient>(PrismaClient, prisma);
-container.registerInstance<RedisClient>(RedisClient, redisClient);
+container.registerInstance<Redis>(Redis, redisClient);
 container.registerInstance<typeof turso>(SHARED_TOKENS.TursoClient, turso);
 
 AuthInfrastructureModule();


### PR DESCRIPTION
Refactor Redis configuration to use `REDIS_HOST` instead of `REDIS_URL` and improve error logging in authentication use cases for better clarity and debugging.